### PR TITLE
Transition from faker.js to @faker-js/faker

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,10 @@
-import faker from 'faker'
+import faker from '@faker-js/faker'
+import Faker from '@faker-js/faker/lib'
 import deepmerge from 'deepmerge'
 import { Factoria } from './types'
 
 const definitions: Record<string, {
-  attributes: (faker: Faker.FakerStatic) => Factoria.Attributes,
+  attributes: (faker: Faker) => Factoria.Attributes,
   states: Record<string, Factoria.StateDefinition>
 }> = {}
 
@@ -91,7 +92,7 @@ factory.states = (...states) => {
 
 factory.define = <T> (
   name: string,
-  attributes: (faker: Faker.FakerStatic) => Factoria.Overrides<T>,
+  attributes: (faker: Faker) => Factoria.Overrides<T>,
   states: Record<string, Factoria.StateDefinition> = {}
 ) => {
   definitions[name] = { attributes, states }

--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
     "schema"
   ],
   "peerDepedencies": {
-    "faker": "^4.1.0"
+    "@faker-js/faker": "^6.0.0-alpha.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-typescript": "^7.9.0",
+    "@faker-js/faker": "^6.0.0-alpha.3",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.1.1",
     "@rollup/plugin-typescript": "^4.1.1",
-    "@types/faker": "^4.1.11",
     "@types/jest": "^26.0.20",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
@@ -48,7 +48,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "faker": "4.1.0",
     "husky": "^5.0.9",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.4",

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Simplistic model factory for Node/JavaScript, heavily inspired by Laravel's [Mod
 # install factoria
 $ yarn add factoria -D
 # install Faker as a peer dependency
-$ yarn add faker -D
+$ yarn add @faker-js/faker -D
 ```
 
 ## Usage

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -1,7 +1,7 @@
 import factory from '../index'
 
 factory.define<User>('user', faker => ({
-  id: faker.random.uuid(),
+  id: faker.datatype.uuid(),
   name: faker.name.findName(),
   email: faker.internet.email(),
   verified: true
@@ -15,7 +15,7 @@ factory.define<User>('user', faker => ({
 })
 
 factory.define<Company>('company', faker => ({
-  id: faker.random.uuid(),
+  id: faker.datatype.uuid(),
   manager: factory('user')
 }), {
   hasUnverifiedManager: faker => ({

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable jest/expect-expect */
 import factory from './factory'
+import Faker from '@faker-js/faker/lib'
 
 const keys = <O extends Object> (obj: O): Array<keyof O> => {
   return Object.keys(obj) as Array<keyof O>
@@ -38,7 +39,7 @@ describe('basic functionalities', () => {
   })
 
   it('supports functions as property overrides', () => {
-    assertUser(factory<User>('user', { email: (faker: Faker.FakerStatic) => 'foo@bar.net' }), {
+    assertUser(factory<User>('user', { email: (faker: Faker) => 'foo@bar.net' }), {
       email: 'foo@bar.net'
     })
   })
@@ -59,7 +60,7 @@ describe('basic functionalities', () => {
   it('supports nested attributes with function overrides', () => {
     const company = factory<Company>('company', {
       manager: {
-        name: (faker: Faker.FakerStatic) => faker.fake('Bob the CEO')
+        name: (faker: Faker) => faker.fake('Bob the CEO')
       }
     })
     assertUser(company.manager, { name: 'Bob the CEO' })


### PR DESCRIPTION
After [the recent Faker incident in the JS community](https://fakerjs.dev/update.html#i-heard-something-happened-what-s-the-tldr), Marak's "faker" package is no longer maintained nor safe.

Fortunately, a number of forks and alternatives have popped up, most-notably [@faker-js/faker](https://fakerjs.dev/).

This PR updates Factoria to use @faker-js/faker instead of faker. As a bonus, the new version has been rewritten in TypeScript, so [we no longer need the @types/faker dependency](https://fakerjs.dev/update.html#what-has-the-team-done-so-far).