### PR TITLE
ci: add release workflow that publishes on v* tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # for npm provenance
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION="v$(node -p 'require("./package.json").version')"
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $TAG does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # for npm provenance
+      id-token: write  # required for npm trusted publishing (OIDC)
 
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +22,10 @@ jobs:
           node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
+
+      # Trusted publishing requires npm >= 11.5.1; node 22 ships with npm 10.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Verify tag matches package.json version
         run: |
@@ -42,6 +46,4 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` so that pushing a `v*` tag triggers `npm publish`. Without this, tags don't go anywhere — npm doesn't watch git tags by itself.

## What it does

- Triggers on tags matching `v*` (e.g. `v5.0.0`, `v5.1.0`).
- Verifies the tag matches `package.json#version` — catches divergence early.
- Bumps npm to `latest` (trusted publishing requires npm ≥ 11.5.1; node 22 ships with npm 10).
- Runs `pnpm test` and `pnpm build` before publishing.
- `npm publish --access public`. No token. Auth is via npm trusted publishing (OIDC) — the workflow gets a short-lived token from npm scoped to this exact repo + workflow. Provenance is attached automatically.

## Required setup on npm side (one-time)

Visit the package settings on npmjs.com → **Trusted publishers** → Add a publisher:
- Publisher: GitHub Actions
- Organization or user: `phanan`
- Repository: `factoria`
- Workflow filename: `release.yml`
- Environment name: *(leave blank)*

Once that's saved, no secret is needed in this repo.

## Test plan

- [ ] Configure trusted publisher on npm (one-time)
- [ ] Merge this PR
- [ ] Tag and push `v5.0.0` from `master`
- [ ] Confirm the Release workflow runs green and `factoria@5.0.0` appears on npm with provenance attestation